### PR TITLE
bugfix: renamed columns for position_x_position_y

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181008195748) do
+ActiveRecord::Schema.define(version: 20181013151031) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,10 +19,11 @@ ActiveRecord::Schema.define(version: 20181008195748) do
     t.string   "name"
     t.string   "type"
     t.string   "color"
-    t.integer  "postion_x"
-    t.integer  "postion_y"
+    t.integer  "position_x"
+    t.integer  "position_y"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer  "game_id"
   end
 
   create_table "games", force: :cascade do |t|


### PR DESCRIPTION
Please review and approve. This is a migration to change the spelling of postion_x and postion_y to position_x and position_y in the chess_pieces table and resolves the issue that was created earler.